### PR TITLE
Fix broken image links and formats introduction in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,10 @@
 
-.. image:: https://mybinder.org/badge.svg :target: https://mybinder.org/v2/gh/mbnshtck/jupyter-kql-magic/master?filepath=notebooks%2FQuickStart.ipynb
+.. image:: https://mybinder.org/badge.svg
+    :target: https://mybinder.org/v2/gh/mbnshtck/jupyter-kql-magic/master?filepath=notebooks%2FQuickStart.ipynb
 
 
-.. image:: https://mybinder.org/badge.svg :target: https://mybinder.org/v2/gh/mbnshtck/jupyter-kql-magic/master?filepath=notebooks%2FQuickStartAI.ipynb
+.. image:: https://mybinder.org/badge.svg
+    :target: https://mybinder.org/v2/gh/mbnshtck/jupyter-kql-magic/master?filepath=notebooks%2FQuickStartAI.ipynb
 
 
 jupyter-Kqlmagic

--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,7 @@
 jupyter-Kqlmagic
 ===========
 
-Extension (Magic) to Jupyter notebook and Jupyter lab, that enable notebook experience working with Kusto, ApplicationInsights, and LogAnalytics data. 
-===========
+An extension (Magic) to Jupyter notebook and Jupyter lab, that enables notebook experience working with Kusto, ApplicationInsights, and LogAnalytics data. 
 
 :Author: Michael Binshtock, mbnshtck@gmail.com
 
@@ -20,10 +19,6 @@ Introduces a %kql (or %%kql) magic.
 
 Connect to kusto, using a connect strings, then issue KQL
 commands within IPython or IPython Notebook.
-
-.. image:: https://github.com/mbnshtck/jupyter-kql-magic/master/examples/writers.png
-   :width: 600px
-   :alt: screenshot of jupyter-kql-magic in the Notebook
 
 Examples
 --------


### PR DESCRIPTION
This PR fixes the formating for the images linking to mybinder.org and removes a non-existing example picture. Also removes the formating for the introduction sentence thats currently shown as a second title