### PR TITLE
Separating parameter `let` statements with newlines

### DIFF
--- a/azure/Kqlmagic/parameterizer.py
+++ b/azure/Kqlmagic/parameterizer.py
@@ -38,7 +38,7 @@ class Parameterizer(object):
         parameters = self._detect_parameters(query_let_statments)
         statements = self._build_let_statements(parameters)
         statements.append(query_body)
-        return query_management_prefix + ";".join(statements)
+        return query_management_prefix + ";\n".join(statements)
 
     def _object_to_kql(self, v) -> str:
         try:


### PR DESCRIPTION
Currently, when parameterizing a Kusto query, all the `let` statements from the replaced parameters are piled up on the same line
```
let foo = 'blah';let bar = 'blahblah';[query body]
```
This change is to have one parameter `let` statement per line.
```
let foo = 'blah';
let bar = 'blahblah';
[query body]
```