### PR TITLE
Fix parameterizer to better handle strings and to also handle pandas …

### DIFF
--- a/azure/Kqlmagic/parameterizer.py
+++ b/azure/Kqlmagic/parameterizer.py
@@ -9,7 +9,7 @@ from datetime import timedelta, datetime
 
 
 import six
-from pandas import DataFrame
+from pandas import DataFrame, Series
 
 
 from .constants import Constants
@@ -51,7 +51,7 @@ class Parameterizer(object):
     def _object_to_kql(self, v) -> str:
         try:
             val = (
-                f"'{v}'"
+                repr(v)
                 if isinstance(v, str)
                 else "null"
                 if v is None
@@ -64,7 +64,7 @@ class Parameterizer(object):
                 else f"dynamic({json.dumps(dict(v), cls=ExtendedJSONEncoder)})"
                 if isinstance(v, dict)
                 else f"dynamic({json.dumps(list(v), cls=ExtendedJSONEncoder)})"
-                if isinstance(v, list)
+                if isinstance(v, (list,Series))
                 else f"dynamic({json.dumps(list(tuple(v)) ,cls=ExtendedJSONEncoder)})"
                 if isinstance(v, tuple)
                 else f"dynamic({json.dumps(list(set(v)), cls=ExtendedJSONEncoder)})"


### PR DESCRIPTION
Currently strings are enclosed in single quotes before passing them on to the request. By using `repr` we can ensure that both single and double quotes are properly handled. Enables following scenario:
```
x = "Zombie's Hand"
%%kql
let _x = x;
datatable(Name: string, Cute: bool) [
"Squirrel", true,
"Zombie's Hand", false
]
| where Name == _x
```

Second portion is to handle a pandas Series as a list rather than a string, this enables a lot of scenarios when Series are being used in different areas and not having to convert them into lists beforehand.

Continuation from previous snippet:
```
cute_names = _kql_raw_result.Name
%%kql
let _c = cute_names;
datatable(Name: string, IsAlive: bool) [
"Squirrel", true,
"Zombie's Hand", false
]
| where Name in (_c)
```