### PR TITLE
Add support for Log Analytics "Implicit Cross Resource Queries"

### DIFF
--- a/azure/Kqlmagic/draft_client.py
+++ b/azure/Kqlmagic/draft_client.py
@@ -193,6 +193,9 @@ class DraftClient(object):
             response = requests.get(api_url, headers=request_headers)
         else:
             request_payload = {"query": query}
+            workspaces = options.get("workspaces")
+            if workspaces is not None:
+                request_payload['workspaces'] = workspaces
             logger().debug("DraftClient::execute - POST request - url: %s, headers: %s, payload: %s, timeout: %s", api_url, log_request_headers, request_payload, options.get("timeout"))
             response = requests.post(api_url, headers=request_headers, json=request_payload)
 

--- a/azure/Kqlmagic/parser.py
+++ b/azure/Kqlmagic/parser.py
@@ -430,6 +430,7 @@ class Parser(object):
         "query": {"flag": "query", "type": "str", "init": "None"},
         "conn": {"flag": "conn", "type": "str", "init": "None"},
         "queryproperties": {"flag": "query_properties", "type": "dict", "init": "None"},
+        "workspaces": {"flag": "workspaces", "type": "list", "init": "None"},
 
         "pc": {"abbreviation": "palettecolors"},
         "palettecolors": {"flag": "palette_colors", "type": "int", "config": "config.palette_colors"},
@@ -645,6 +646,8 @@ class Parser(object):
                 return bool(val)
             elif _type == "dict":
                 return dict(val)
+            elif _type == "list":
+                return list(val)
             elif _type == "enum":
                 if enums.index(val):
                     return str(val)

--- a/notebooks/QuickStartLA.ipynb
+++ b/notebooks/QuickStartLA.ipynb
@@ -930,6 +930,47 @@
   },
   {
    "cell_type": "markdown",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Kql query with option -workspaces\n",
+    "\n",
+    "Implicitly unions the source tables from all the provided workspaces with the table provided in the connection string. The workspace from the connection string does not need to be repeated in the workspaces option."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Can contain any number of Log Analytics workspace GUIDs. \n",
+    "my_workspaces = ['63613592-b6f7-4c3d-a390-22ba13102111', 'b438b4f6-912a-46d5-9cb1-b44069212abc']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%kql -workspaces my_workspaces\n",
+    "    Heartbeat \n",
+    "    | distinct TenantId"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "  - ### <span style=\"color:#82CAFA\">*Note: The workspaces option doesn't work with DEMO_KEY authentication.*</span>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Kql query with negated option -f (-feedback)"


### PR DESCRIPTION
Adds a "-workspaces" option that can be used to fill in the payload argument `workspaces` in the Log Analytics query API.

https://dev.loganalytics.io/documentation/Using-the-API/Cross-Resource-Queries