### PR TITLE
Fix quote in dataframe handing of parameterizer

### DIFF
--- a/azure/Kqlmagic/parameterizer.py
+++ b/azure/Kqlmagic/parameterizer.py
@@ -157,7 +157,7 @@ class Parameterizer(object):
                 return self._object_to_kql(val)
          
         # this is the best we not specified
-        return "" if s is None else f"'{s}'"
+        return "" if s is None else repr(s)
 
         
     def guess_object_types(self, pairs_type:dict, r:list) -> dict:

--- a/azure/Kqlmagic/parameterizer.py
+++ b/azure/Kqlmagic/parameterizer.py
@@ -9,7 +9,7 @@ from datetime import timedelta, datetime
 
 
 import six
-from pandas import DataFrame
+from pandas import DataFrame, Series
 
 
 from .constants import Constants
@@ -51,7 +51,7 @@ class Parameterizer(object):
     def _object_to_kql(self, v) -> str:
         try:
             val = (
-                f"'{v}'"
+                repr(v)
                 if isinstance(v, str)
                 else "null"
                 if v is None
@@ -64,7 +64,7 @@ class Parameterizer(object):
                 else f"dynamic({json.dumps(dict(v), cls=ExtendedJSONEncoder)})"
                 if isinstance(v, dict)
                 else f"dynamic({json.dumps(list(v), cls=ExtendedJSONEncoder)})"
-                if isinstance(v, list)
+                if isinstance(v, (list,Series))
                 else f"dynamic({json.dumps(list(tuple(v)) ,cls=ExtendedJSONEncoder)})"
                 if isinstance(v, tuple)
                 else f"dynamic({json.dumps(list(set(v)), cls=ExtendedJSONEncoder)})"


### PR DESCRIPTION
Use repr against dataframe strings as well, similar to #50 , except applying to values within dataframes.

First query
```python
x = "Zombie's Hand"
%%kql
let _x = x;
datatable(Name: string, Cute: bool) [
"Squirrel", true,
"Zombie's Hand", false
]
| where Name == _x
```

Use that dataframe later on
```python
%%kql
let _c = _kql_raw_result;
_c
| extend Dead = "True"
```