### PR TITLE
Add undeclared import dependency on azure-common pkg to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ INSTALL_REQUIRES    = [
                         'pyperclip>=1.7.0',
                         'azure-cli-core>=2.4.0',
                         'msrestazure>=0.6.0',
+                        'azure-common>=1.1.25',
 ]
 
 TEST_REQUIRE        = [


### PR DESCRIPTION
This PR is to resolve #60 which is caused by a `ModuleNotFoundError: No module named 'azure.common'` that throws at this line when the user tries to utilize the `-try-azcli-login` connection string option. Adding azure-common as a dependency in setup.py resolves the error.

https://github.com/microsoft/jupyter-Kqlmagic/blob/55770382a2a527d852481b3b65a3ec07ce2d0167/azure/Kqlmagic/my_aad_helper.py#L635