### PR TITLE
Allow @ symbol in filename root_path for Kqlmagic initialization

### DIFF
--- a/azure/Kqlmagic/my_utils.py
+++ b/azure/Kqlmagic/my_utils.py
@@ -41,7 +41,7 @@ def get_valid_filename_with_spaces(name:str)->str:
     """
     # name = str(name).strip().replace(' ', '_')
     name = str(name).strip()
-    return re.sub(r'(?u)[^-\w. ]', '', name)
+    return re.sub(r'(?u)[^-\w.@ ]', '', name)
 
 
 # Expression to match some_token and some_token="with spaces" (and similarly


### PR DESCRIPTION
#### Pull Request Description

This PR fixes the bug reported in Issue #100 

---

#### Future Release Comment
Before this fix, Kqlmagic initialization failed in restricted environments where new folder creation at user root (/home/user@domain) level is not allowed. The reason for this fail was, while trying to create Kqlmagic initialization folder, the root_path variable omitted @ symbol from path, which resulted in a non-existent path that needed to be created. Since the @ symbol often only existed in the user's home directory, it was not possible to create a new folder at user root level, leading to PermissionError and failure to initialize Kqlmagic.

Example:
If the following Kqlmagic initialization folder needs to be created: ```kqlmagic/temp_files/<kernel-id>``` at the root_path ```/home/user@domain``` then the expected outcome should be a new folder ```/home/user@domain/kqlmagic/temp_files/<kernel-id>```. However, the function
https://github.com/microsoft/jupyter-Kqlmagic/blob/b1c4d26491b4c67d2b4bee782c19fbf88cf634e9/azure/Kqlmagic/kql_magic_core.py#L294
would return the following file path ```/home/userdomain/kqlmagic/temp_files/<kernel-id>``` to be created.

Tracing this ```adjust_path``` function call -->
https://github.com/microsoft/jupyter-Kqlmagic/blob/b1c4d26491b4c67d2b4bee782c19fbf88cf634e9/azure/Kqlmagic/my_utils.py#L131-L134
https://github.com/microsoft/jupyter-Kqlmagic/blob/b1c4d26491b4c67d2b4bee782c19fbf88cf634e9/azure/Kqlmagic/my_utils.py#L126-L128
https://github.com/microsoft/jupyter-Kqlmagic/blob/b1c4d26491b4c67d2b4bee782c19fbf88cf634e9/azure/Kqlmagic/my_utils.py#L96-L123
https://github.com/microsoft/jupyter-Kqlmagic/blob/b1c4d26491b4c67d2b4bee782c19fbf88cf634e9/azure/Kqlmagic/my_utils.py#L36-L44

we arrive at the Regex substitution line, where it removes the @ symbol as well. The original intent derived from comments is to 
- remove leading and trailing spaces
- convert other spaces to underscores
- remove anything that is not an alphanumeric, dash, underscore, or dot.

The patch modifies the Regex substitution to include the @ symbol and thereby solving the reported bug.


**Breaking Changes:**
- None

**Features:**
- None

**Fixes:**
- Updated ```azure/Kqlmagic/my_utils.py```