### PR TITLE
* Get a working copy of auth on Fabric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,5 @@ C:\MyProjects\KqlmagicAtMicrosoftGithub\jupyter-Kqlmagic\azure\tests\Kqlmagic_te
 azure/Kqlmagic/kql_magic_old.py
 /notebooks/kqlmagic/temp_files
 pyvenv.cfg
+
+*.whl

--- a/azure/Kqlmagic/_version.py
+++ b/azure/Kqlmagic/_version.py
@@ -28,7 +28,7 @@
 # (1, 2, 0, 'final', 0) => "1.2"
 
 
-__version_info__ = (0, 1, 114, "post", 24)
+__version_info__ = (0, 1, 114, "post", 25)
 
 assert len(__version_info__) == 5
 assert __version_info__[3] in ('dev', 'alpha', 'beta', 'rc', 'final', 'post')

--- a/azure/Kqlmagic/my_aad_helper_msal.py
+++ b/azure/Kqlmagic/my_aad_helper_msal.py
@@ -868,16 +868,16 @@ class _MyAadHelper(AadHelper):
         sys.stderr = StringIO()
         try:
             logger().debug(f"_MyAadHelper::_get_fabric_token enter getting token for resource {self._resource}")
-            ## An access token JWT is returned from the API call
+            # An access token JWT is returned from the API call
+            # In non-fabric environments there is no token returned. This does not throw an error, but just returns None
             t = mssparkutils.credentials.getToken(self._resource)
             if t:
                 token = {"access_token": t, "token_type": "bearer"}
                 sys.stderr = old_stderr or sys.stderr
-                return token
         except Exception as error:
             logger().debug(f"_MyAadHelper::_get_fabric_token error getting token with error {error}")
-            pass
-        logger().debug(f"_MyAadHelper::_get_fabric_token {'failed' if token is None else 'succeeded'} to get token")
+            token = None
+        logger().info(f"_MyAadHelper::_get_fabric_token {'failed' if token is None else 'succeeded'} to get token")
         return token
 
     def _get_aux_token(self, token:dict)->str:

--- a/azure/Kqlmagic/my_aad_helper_msal.py
+++ b/azure/Kqlmagic/my_aad_helper_msal.py
@@ -385,14 +385,6 @@ class _MyAadHelper(AadHelper):
                 self._current_scopes = None
                 self._current_username = None
 
-            # The attempt is to get a 1P token, if not available, then try other methods
-            if self._current_token is None:
-                logger().debug("Attempting to get 1P token for authentication")
-                token = self._get_1P_token()
-                if token is not None:
-                    self._current_token = self._validate_and_refresh_token(token)
-                logger().debug("1P token is not available, attempting other auth methods")
-
             if self._current_token is None:
                 if self._options.get("try_token") is not None:
                     token = self._get_aux_token(token=self._options.get("try_token"))
@@ -422,6 +414,15 @@ class _MyAadHelper(AadHelper):
                 if self._options.get("try_vscode_login"):
                     token = self._get_vscode_token()
                     self._current_token = self._validate_and_refresh_token(token)
+
+            # The attempt is to get a 1P token, if not available, then use device code login
+            if self._current_token is None:
+                logger().debug("Attempting to get 1P token for authentication")
+                token = self._get_1P_token()
+                if token is not None:
+                    self._current_token = self._validate_and_refresh_token(token)
+                logger().debug("1P token is not available, attempting other auth methods")
+
 
             if self._current_token is None:
                 self._current_authentication_method = self._authentication_method

--- a/azure/Kqlmagic/my_aad_helper_msal.py
+++ b/azure/Kqlmagic/my_aad_helper_msal.py
@@ -386,10 +386,6 @@ class _MyAadHelper(AadHelper):
                 self._current_scopes = None
                 self._current_username = None
 
-            if self._current_token is None:
-                if self._resource.find("data.microsoft.com") > 0 or self._resource.find("fabric.microsoft.com") > 0:
-                    token = self._get_fabric_token()
-                    self._current_token = self._validate_and_refresh_token(token)
 
             if self._current_token is None:
                 if self._options.get("try_token") is not None:
@@ -439,7 +435,13 @@ class _MyAadHelper(AadHelper):
                     self._current_token = self._acquire_msal_token_silent()
 
             if self._current_token is None:
-                logger().debug("*No suitable token exists in cache. Let's get a new one from AAD(default)*")
+                if self._resource.find("data.microsoft.com") > 0 or self._resource.find("fabric.microsoft.com") > 0:
+                    logger().debug("No suitable token exists in cache & the source is a fabric cluster. Try and get a fabric token")
+                    token = self._get_fabric_token()
+                    self._current_token = self._validate_and_refresh_token(token)
+
+            if self._current_token is None:
+                logger().debug("No suitable token exists in cache. Let's get a new one from AAD(default)")
                 self._current_msal_client_app = self._msal_client_app_sso or self._msal_client_app
 
                 if self._authentication_method is AuthenticationMethod.aad_username_password:
@@ -860,12 +862,10 @@ class _MyAadHelper(AadHelper):
     def _get_fabric_token(self)->str:
         logger().debug("*_MyAadHelper::_get_fabric_token enter*")
         token = None
-        logger().debug("*_MyAadHelper::_get_fabric_token enter - 2")
         self._current_authentication_method = AuthenticationMethod.fabric
         logger().debug("*_MyAadHelper::_get_fabric_token enter - 3")
         old_stderr = sys.stderr
         sys.stderr = StringIO()
-        logger().debug("*_MyAadHelper::_get_fabric_token enter - 4")
         try:
             logger().debug(f"_MyAadHelper::_get_fabric_token enter getting token for resource {self._resource}")
             ## An access token JWT is returned from the API call

--- a/azure/Kqlmagic/my_aad_helper_msal.py
+++ b/azure/Kqlmagic/my_aad_helper_msal.py
@@ -8,7 +8,6 @@
 """
 
 import os
-import traceback
 import sys
 from io import StringIO
 import time
@@ -875,7 +874,6 @@ class _MyAadHelper(AadHelper):
                 sys.stderr = old_stderr or sys.stderr
                 return token
         except Exception as error:
-            traceback.print_stack()
             logger().debug(f"_MyAadHelper::_get_fabric_token error getting token with error {error}")
             pass
         logger().debug(f"_MyAadHelper::_get_fabric_token {'failed' if token is None else 'succeeded'} to get token")

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -5,3 +5,4 @@ nose>=1.3.7
 twine>=1.12.1
 black;python_version == '3.6'
 wheel>=0.43.0
+dummy-notebookutils>=1.5.1


### PR DESCRIPTION
#### Pull Request Description

For fabric runtime, enable an auto login.

---

#### Future Release Comment

This can be done for Synapse as well. Will extend it for synapse hosts and runtimes.

**Breaking Changes:**
- None

**Features:**
- Auto login for Fabric

![image](https://github.com/microsoft/jupyter-Kqlmagic/assets/106139410/5d67f87d-bc76-4c39-bca7-f684a2b628c2)


**Fixes:**
- None