### PR TITLE
Prefer `database_name` rather than `NetDefaultDB` for `.show databases`

### DIFF
--- a/azure/Kqlmagic/kusto_engine.py
+++ b/azure/Kqlmagic/kusto_engine.py
@@ -143,7 +143,7 @@ class KustoEngine(KqlEngine):
 
     def _get_databases_by_pretty_name(self, **options)->Tuple[List[str],Dict[str,str]]:
         query = ".show databases"
-        kql_response = self.execute(query, database="NetDefaultDB", **options)
+        kql_response = self.execute(query, database=self.database_name or "NetDefaultDB", **options)
         table = kql_response.tables[0]
         databases_by_pretty_name = {row['PrettyName']: row['DatabaseName'] for row in table.fetchall() if row['PrettyName']}
         database_name_list = [row['DatabaseName'] for row in table.fetchall()]


### PR DESCRIPTION
Fix https://github.com/microsoft/jupyter-Kqlmagic/issues/106

When `self.database_name` is available, prefer submitting `.show databases` queries against that database rather than `NetDefaultDB` since this works when the account in use only has access to the target database (i.e. very restrictive ACL situations such as the Office team's ARIA database).

#### Future Release Comment
**Fixes:**
- https://github.com/microsoft/jupyter-Kqlmagic/issues/106