### PR TITLE
[bugfix]: Fixes data ingestions for table contains column name with dash

### DIFF
--- a/azure/Kqlmagic/parameterizer.py
+++ b/azure/Kqlmagic/parameterizer.py
@@ -318,7 +318,7 @@ class Parameterizer(object):
         r = d["data"]
         pairs_t = {col: [str(t[col]), cls._DATAFRAME_TO_KQL_TYPES.get(str(t[col]))] for col in c}
         pairs_t = cls._guess_object_types(pairs_t, r)
-        schema = ", ".join([f"{col}:{pairs_t[col][1]}" for col in c])
+        schema = ", ".join([f'["{str.strip(col)}"]:{pairs_t[col][1]}' for col in c])
         data = ", ".join([", ".join([cls._dataframe_to_kql_value(val, pairs_t[c[idx]]) for idx, val in enumerate(row)]) for row in r])
         return f" view () {{datatable ({schema}) [{data}]}}"      
  


### PR DESCRIPTION
#### Pull Request Description
fixes kql operation for column names dash in them eg column-Name

was failing with error Syntax error: SYN0002. Expected: :
Before Fix:
Query formed:
![image](https://github.com/user-attachments/assets/e24c5eb5-3e7b-4d89-b6af-9620a4c70f0b)
Error occured:
![image](https://github.com/user-attachments/assets/56ab8fb0-139e-43b4-a713-788564ac5f0a)


After fix:
Query:
![image](https://github.com/user-attachments/assets/8b323218-0761-41a0-8407-c5d8da92e737)
Success:
![image](https://github.com/user-attachments/assets/6721fb6b-083e-4be9-84c1-ee52311bbabb)

 

**Breaking Changes:**
- None

**Features:**
- None

**Fixes:**
- None